### PR TITLE
Lock Framebuffer and Cursor Handling

### DIFF
--- a/trmnl-display.go
+++ b/trmnl-display.go
@@ -126,6 +126,9 @@ func main() {
 	}
 	defer fbLock.Release()
 
+	// Clear the framebuffer at startup
+	clearFramebuffer()
+
 	for {
 		processNextImage(tmpDir, config.APIKey, options)
 	}


### PR DESCRIPTION
This PR introduces several enhancements to ensure exclusive framebuffer access, improves user experience by disabling the cursor during framebuffer usage, and ensures a clean environment on application launch.

### Key Changes:

- **Framebuffer Locking:**
  - Adds a robust locking mechanism (`FramebufferLock`) to prevent concurrent framebuffer access.
  - Ensures lock acquisition and automatic cleanup, including removal of stale lock files.

- **Cursor Management:**
  - Implements multiple methods to disable the cursor effectively on application start:
    - Terminal settings adjustment (`ioctl` syscall).
    - Escape sequences for terminal cursor visibility.
    - Sysfs control for cursor blinking.
    - Stopping GPM mouse daemon if detected.
  - Automatically restores cursor visibility on exit or signal interrupt.

- **Framebuffer Clearing:**
  - Ensures framebuffer is cleared to black on startup to provide a clean display environment.

- **Verbose Mode:**
  - Enhances logging with an optional verbose mode for detailed runtime diagnostics.

### Testing:
-  [✅ SUCCESS] Confirmed framebuffer lock acquisition and proper handling of stale locks.
-  [✅ SUCCESS] Verified cursor visibility is successfully managed across multiple environments.
-  [❌ FAIL] Tested framebuffer clearing at launch and proper restoration on application exit