### PR TITLE
Add support for custom base URL and Terminus/BYOS servers

### DIFF
--- a/trmnl-display.go
+++ b/trmnl-display.go
@@ -394,7 +394,8 @@ func processNextImage(tmpDir string, config Config, options AppOptions) {
 	}()
 
 	// Get the TRMNL display
-	req, err := http.NewRequest("GET", config.BaseURL+"/api/display", nil)
+	apiURL := strings.TrimRight(config.BaseURL, "/") + "/api/display"
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		fmt.Printf("Error creating request: %v\n", err)
 		time.Sleep(60 * time.Second)
@@ -417,7 +418,10 @@ func processNextImage(tmpDir string, config Config, options AppOptions) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		fmt.Printf("Error fetching display: status code %d\n", resp.StatusCode)
+		fmt.Printf("Error fetching display from %s: status code %d\n", apiURL, resp.StatusCode)
+		if options.Verbose && resp.StatusCode == 404 {
+			fmt.Printf("API endpoint not found. Please verify the base URL is correct.\n")
+		}
 		time.Sleep(60 * time.Second)
 		return
 	}

--- a/trmnl-display.go
+++ b/trmnl-display.go
@@ -434,6 +434,10 @@ func processNextImage(tmpDir string, config Config, options AppOptions) {
 	} else {
 		// For Terminus/BYOS servers, use ID header with MAC address
 		req.Header.Add("ID", config.DeviceID)
+		// Also add access-token for BYOS Laravel compatibility
+		if config.APIKey != "" {
+			req.Header.Add("access-token", config.APIKey)
+		}
 		req.Header.Add("Content-Type", "application/json")
 	}
 	req.Header.Add("battery-voltage", "100.00")


### PR DESCRIPTION
## Summary

  - Added configurable base URL support to allow using alternative TRMNL API endpoints
  - Implemented automatic detection and authentication for Terminus/BYOS servers
  - Improved configuration handling with clear distinction between API keys and device IDs

## Changes

  - Custom Base URL: Users can now specify a custom API endpoint via:
    - Command-line flag: --base-url
    - Environment variable: TRMNL_BASE_URL
    - Config file: base_url field
  - Terminus/BYOS Server Support:
    - Automatically detects when using non-trmnl.app servers
    - Uses ID header with device MAC address for Terminus servers
    - Uses access-token header with API key for standard trmnl.app
    - New TRMNL_DEVICE_ID environment variable for Terminus device IDs
  - Improved Configuration:
    - Separate APIKey and DeviceID fields for clarity
    - Smart prompts that ask for appropriate credentials based on server type
    - Automatic migration of MAC addresses previously stored as API keys

## Breaking Changes

  None - fully backward compatible. Existing configurations will continue to work.

## Testing

  - Tested with official trmnl.app API ✓
  - Tested with Terminus server using MAC address authentication ✓
  - Verified proper header selection based on base URL ✓