### PR TITLE
Suggestion: Add full date and time when in verbose mode

### DIFF
--- a/trmnl-display.go
+++ b/trmnl-display.go
@@ -354,8 +354,9 @@ func displayImage(imagePath string, options AppOptions, frames int) error {
 		os.Exit(0);
         }
 	if options.Verbose {
-		fmt.Printf("Displayed: %s\n", imagePath)
-		fmt.Println("EPD update completed")
+        now := time.Now().Format(time.RFC3339)
+        fmt.Printf("[%s] Displayed: %s\n", now, imagePath)
+        fmt.Printf("[%s] EPD update completed\n", now)
 	}
 	return nil
 }


### PR DESCRIPTION
Hello Folks, 

  I know this can be understood as optional or a personal preference, but when you enable verbose mode, we normally expect to see timestamps throughout to help investigate potential problems. For example, when investigating issues with the image generation or just updating the local e-ink, this can help to understand when the images were generated and rotated, see image bellow.

This pull request improves the logging output for the `displayImage` function by adding timestamps to verbose log messages. This change helps with debugging and tracking when specific actions occur during execution.

Logging improvements:

* Updated verbose log messages in the `displayImage` function in `trmnl-display.go` to include RFC3339-formatted timestamps for better traceability.

### Example
<img width="924" height="399" alt="image" src="https://github.com/user-attachments/assets/e4f29e83-64c3-411b-bd7e-78193ef7b55c" />
