### PR TITLE
Added GitHub Workflow for automating releases

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,31 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module trmnl-display
+
+go 1.24.0


### PR DESCRIPTION
This pull request adds a GitHub Actions Workflow that automatically builds the project, and then creates a release. This allows users to access the binary without requiring installation of the Go buildchain - just simply push a tag to the repo and it will create a release.

Example Release: https://github.com/R4wizard/trmnl-display/releases/tag/v0.1.2
Example Execution: https://github.com/R4wizard/trmnl-display/actions/runs/22081191313/job/63806537934