### PR TITLE
Added `--sixel` flag for outputing current image with Sixels to StdOut

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module trmnl-display
+
+go 1.24.0
+
+require github.com/mattn/go-sixel v0.0.8
+
+require github.com/soniakeys/quant v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-sixel v0.0.8 h1:H0bBGQVOJoSvzvtTgCInxvg1IZiNlTcIIIx8A6uvjpQ=
+github.com/mattn/go-sixel v0.0.8/go.mod h1:wbDSbrwpykVI1qEHyjZYsDgaJTwpVg9wSwmmh2slnBw=
+github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=
+github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=


### PR DESCRIPTION
This pull request adds support for outputting the current image to the stdout terminal using the [Sixel](https://en.wikipedia.org/wiki/Sixel) graphics format.

<img width="934" height="704" alt="image" src="https://github.com/user-attachments/assets/443fa387-e192-4be2-a1a4-e666a1d781d4" />
