### PR TITLE
enlarging the PNGdec buffer so full-colour images can decode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,14 +38,19 @@ set -e
       git clone https://github.com/bitbank2/JPEGDEC
   fi
 
+  # PNGdecs scanline buffer defaults to 320px @ 32bpp, so show_img
+  # rejects any color image wider than that with PNG_TOO_BIG. For colour I had to enlarge it to two 2048px @ 32bpp scanlines = 16386 bytes
+
+  PNG_BUF="-DPNG_MAX_BUFFERED_PIXELS=16386"
+
   cd PNGdec/linux
-  make
+  make CC="${CC:-cc} $PNG_BUF" CXX="${CXX:-g++} $PNG_BUF"
   cd ../../JPEGDEC/linux
   make
   cd ../../bb_epaper/rpi
   make
   cd examples/show_img
-  make
+  make CC="${CC:-cc} $PNG_BUF" CXX="${CXX:-g++} $PNG_BUF"
 # restore the original directory
   popd
   echo "Select your display device:"


### PR DESCRIPTION
### Problem
On a color panel (like my Waveshare 7.3" Spectra 6), `show_img` fails to decode
the dashboard image with `PNG open returned error: Too big`, even if image is
correctly sized at 800×480.

### Root cause
`build.sh` builds `PNGdec` and `show_img` with their stock Makefiles, leaving
`PNG_MAX_BUFFERED_PIXELS` at its embedded default of `((320*4+1)*2)` = 2562
bytes. PNGdec rejects any image with its row pitch reaching that cap.

### Fix
Define `PNG_MAX_BUFFERED_PIXELS=16386` (two 2048px @ 32bpp scanlines; covers
every current Spectra panel up to 13.3″/1600px) for both the `libpngdec`
and `show_img` builds. The value must be consistent because the `PNGIMAGE`
struct that embeds the buffer is allocated in `show_img`'s `main.cpp` but
written by `libpngdec`.

### Testing
Built on a Raspberry Pi 3 B+. An 800×480 8-bit RGBA PNG that had
returned `PNG_TOO_BIG` now decodes and displays on my Waveshare Spectra 6 panel.